### PR TITLE
hw11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,51 @@
 # 为什么不指定 cmake_minimum_required 会导致下面在 project 处出错？
-#cmake_minimum_required(VERSION 3.10)
+# VERSION option in project() command not allowed unless CMP0048 is set to NEW
+cmake_minimum_required(VERSION 3.10)
 
-project(hellocmake VERSION 3.1.4 LANGUAGES CXX)
+project(hellocmake VERSION 3.1.4 LANGUAGES C CXX)
 
 # 如何让构建类型默认为 Release？
-#set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message("Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+        "MinSizeRel" "RelWithDebInfo")
+endif()
 
-# 这样设置 C++14 的方式对吗？请改正
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14")
+# 这样设置 C++14 的方式对吗？请改正 -> 不对
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # （可选）使用 ccache 加速编译
-find_program(CCACHE_PROGRAM ccache)
+if (NOT MSVC)
+    find_program(CCACHE_PROGRAM ccache)
+    if (CCACHE_PROGRAM)
+        message(STATUS "Found CCache : ${CCACHE_PROGRAM}")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_PROGRAM})
+    endif()
+endif()
 
 # legacy/CMakeLists.txt 和 mylib/CMakeLists.txt 里还有问题哦！
 add_subdirectory(legacy)
 add_subdirectory(mylib)
 
 # 这样需要一个个写出所有文件很麻烦，请改成自动批量添加源文件
-set(main_sources "src/main.cpp" "src/other.cpp" "src/dummy.cpp" "src/veryusefulfile.cpp")
+file(GLOB main_sources CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h)
 add_executable(main ${main_sources})
 
-# 请改为项目的正确版本（用变量来获取）
-target_compile_definitions(main PRIVATE HELLOCMAKE_VERSION="233.33.33")
+# Link libraries
+target_link_libraries(main PUBLIC mylib)
+if (WIN32)
+    install()
+endif()
+
+# 请改为项目的正确版本（用变量来获取）-> Use configure file
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/in/config.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/config.h @ONLY)
 
 # （可选）添加 run 作为伪目标方便命令行调用
+add_custom_target(run COMMAND $<TARGET_FILE:main>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,10 @@ add_executable(main ${main_sources})
 
 # Link libraries
 target_link_libraries(main PUBLIC mylib)
-if (WIN32)
-    install()
+if (WIN32 AND MSVC)
+    set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE}" CACHE STRING "The path to use for make install" FORCE)
+    install (TARGETS mylib
+        RUNTIME DESTINATION ./)
 endif()
 
 # 请改为项目的正确版本（用变量来获取）-> Use configure file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ file(GLOB main_sources CONFIGURE_DEPENDS
 add_executable(main ${main_sources})
 
 # Link libraries
-target_link_libraries(main PUBLIC mylib)
+target_link_libraries(main PRIVATE mylib)
 if (WIN32 AND MSVC)
     set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE}" CACHE STRING "The path to use for make install" FORCE)
     install (TARGETS mylib

--- a/in/config.h.in
+++ b/in/config.h.in
@@ -1,0 +1,2 @@
+#pragma once
+#define HELLOCMAKE_VERSION "@PROJECT_VERSION@"

--- a/legacy/CMakeLists.txt
+++ b/legacy/CMakeLists.txt
@@ -1,2 +1,2 @@
-# 为什么 legacy 这个只有 .c 文件的对象出错了？
+# 为什么 legacy 这个只有 .c 文件的对象出错了？-> 没在 project( ... LANGUAGES C CXX) 中启用 C
 add_executable(legacy "legacy.c")

--- a/mylib/CMakeLists.txt
+++ b/mylib/CMakeLists.txt
@@ -1,9 +1,9 @@
 # 请改用自动批量查找所有 .cpp 和 .h 文件：
-set(mylib_sources "mylib/mylib.cpp" "mylib/mylib.h")
+file(GLOB mylib_sources CONFIGURE_DEPENDS mylib/*.cpp mylib/*.h)
 
 # 使用 SHARED 在 Windows 上会遇到什么困难？请尝试修复!
 add_library(mylib SHARED ${mylib_sources})
 target_compile_definitions(mylib PRIVATE MYLIB_EXPORT)
 
 # 这里应该用 PRIVATE 还是 PUBLIC？
-target_include_directories(mylib PRIVATE .)
+target_include_directories(mylib PUBLIC .)

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 set -e
 cmake -B build
-cmake --build build
-build/main
+cmake --build build --target run

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,2 @@
+#pragma once
+#define HELLOCMAKE_VERSION "3.1.4"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <string>
 #include <mylib/mylib.h>
+#include "config.h"
 
 int main() {
 #ifdef HELLOCMAKE_VERSION


### PR DESCRIPTION
- 为什么不指定 `cmake_minimum_required()` 会出错
  - `project()` 中的 `VERSION` 关键字需要 `cmake_policy(SET CMP0048 NEW)` 才能使用。调用 `cmake_minimum_required()` 会自动 set 这些 policy 为 new。
- 修改 `LANGUAGES C CXX` 使其支持 c
- mylib 的 `target_include_directories` 应该声明为 `PUBLIC` 以让 executable 引入其头文件
- 如何让构建类型默认为 Release？
  - 使用 set(CMAKE_BUILD_TYPE Release CACHE STRING "..." FORCE)
- 改正 c++14 的设置方式
  - 使用 set()
- 使用 ccache 加速编译
- 为所有 target 改用 GLOB 收集源文件
- 添加 run 作为伪目标方便命令行调用
- 使用 `configure_file` 生成 `config.h` 头文件用来 `#define`
- 使用 `install()` 命令为 wendous 用户拷贝 `.dll` 到执行目录