### PR TITLE
finish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,15 @@
 # 为什么不指定 cmake_minimum_required 会导致下面在 project 处出错？
-#cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10)
 
-project(hellocmake VERSION 3.1.4 LANGUAGES CXX)
+project(hellocmake VERSION 3.1.4 LANGUAGES CXX C)
 
 # 如何让构建类型默认为 Release？
-#set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE Release)
 
 # 这样设置 C++14 的方式对吗？请改正
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14")
+# set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # （可选）使用 ccache 加速编译
 find_program(CCACHE_PROGRAM ccache)
@@ -17,10 +19,12 @@ add_subdirectory(legacy)
 add_subdirectory(mylib)
 
 # 这样需要一个个写出所有文件很麻烦，请改成自动批量添加源文件
-set(main_sources "src/main.cpp" "src/other.cpp" "src/dummy.cpp" "src/veryusefulfile.cpp")
+file(GLOB main_sources src/*.cpp)
 add_executable(main ${main_sources})
+target_link_libraries(main PUBLIC mylib)
 
 # 请改为项目的正确版本（用变量来获取）
-target_compile_definitions(main PRIVATE HELLOCMAKE_VERSION="233.33.33")
+target_compile_definitions(main PRIVATE HELLOCMAKE_VERSION="${PROJECT_VERSION}")
 
 # （可选）添加 run 作为伪目标方便命令行调用
+add_custom_target(run COMMAND $<TARGET_FILE:main>)

--- a/mylib/CMakeLists.txt
+++ b/mylib/CMakeLists.txt
@@ -1,9 +1,11 @@
 # 请改用自动批量查找所有 .cpp 和 .h 文件：
-set(mylib_sources "mylib/mylib.cpp" "mylib/mylib.h")
+# set(mylib_sources "mylib/mylib.cpp" "mylib/mylib.h")
+file( GLOB_RECURSE mylib_sources CONFIGURE_DEPENDS mylib/*.cpp mylib/*.h)
 
 # 使用 SHARED 在 Windows 上会遇到什么困难？请尝试修复!
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_library(mylib SHARED ${mylib_sources})
 target_compile_definitions(mylib PRIVATE MYLIB_EXPORT)
 
 # 这里应该用 PRIVATE 还是 PUBLIC？
-target_include_directories(mylib PRIVATE .)
+target_include_directories(mylib PUBLIC .)

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 set -e
 cmake -B build
-cmake --build build
-build/main
+cmake --build build --target run


### PR DESCRIPTION
为什么不指定 cmake_minimum_required 会导致下面在 project 处出错？
如果本项目使用了新版本特性则无法在老版本cmake上面构建，应当指定版本

如何让构建类型默认为 Release？
直接设置 CMAKE_BUILD_TYPE 为 Release

这样设置 C++14 的方式对吗？请改正
不可以，因为这个编译flag无法跨平台使用

为什么 legacy 这个只有 .c 文件的对象出错了？
因为project没有指定语言包括C，添加上即可

使用 SHARED 在 Windows 上会遇到什么困难？请尝试修复!
未指定库类型则默认库为静态库，动态库无法链接静态库，需要设定PIC为on

这里应该用 PRIVATE 还是 PUBLIC？
PUBLIC,否则库无法被project引用