### PR TITLE
GeLee Hw_11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,45 @@
 # 为什么不指定 cmake_minimum_required 会导致下面在 project 处出错？
-#cmake_minimum_required(VERSION 3.10)
+#因为txt至少需要3.10版本才可以运行
+cmake_minimum_required(VERSION 3.10)
 
-project(hellocmake VERSION 3.1.4 LANGUAGES CXX)
+project(hellocmake VERSION 3.1.4 LANGUAGES CXX C)
 
 # 如何让构建类型默认为 Release？
 #set(CMAKE_BUILD_TYPE Release)
+if(NOT CMake_BUILD_TYPE)
+    set(CMAKE_MODULE_PATH Release)
+endif()
 
 # 这样设置 C++14 的方式对吗？请改正
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14")
+#1.这是针对gcc的用法，对MSVC用户不方便 2.再次添加会导致冲突
+#set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 
 # （可选）使用 ccache 加速编译
-find_program(CCACHE_PROGRAM ccache)
+#不支持MSVC
+if(NOT MSVC)
+    find_program(CCACHE_PROGRAM ccache)
+    if( CCACHE_PROGRAM)
+        message(STATUS "Found CCache: ${CCACHE_PROGRAM}")
+        set_property(GLOBAL PROPERTY  RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_PROGRAM})
+    endif()
+endif()
 
 # legacy/CMakeLists.txt 和 mylib/CMakeLists.txt 里还有问题哦！
 add_subdirectory(legacy)
 add_subdirectory(mylib)
 
 # 这样需要一个个写出所有文件很麻烦，请改成自动批量添加源文件
-set(main_sources "src/main.cpp" "src/other.cpp" "src/dummy.cpp" "src/veryusefulfile.cpp")
+#set(main_sources "src/main.cpp" "src/other.cpp" "src/dummy.cpp" "src/veryusefulfile.cpp")
+file(GLOB_RECURSE main_sources CONFIGURE_DEPENDS src/*.cpp)
 add_executable(main ${main_sources})
+target_link_libraries(main PRIVATE mylib)
 
 # 请改为项目的正确版本（用变量来获取）
-target_compile_definitions(main PRIVATE HELLOCMAKE_VERSION="233.33.33")
+#target_compile_definitions(main PRIVATE HELLOCMAKE_VERSION="233.33.33")
+target_compile_definitions(main PRIVATE HELLOCMAKE_VERSION="${PROJECT_VERSION}")
 
 # （可选）添加 run 作为伪目标方便命令行调用

--- a/legacy/CMakeLists.txt
+++ b/legacy/CMakeLists.txt
@@ -1,2 +1,3 @@
 # 为什么 legacy 这个只有 .c 文件的对象出错了？
+# 因为project没有指定语言为c
 add_executable(legacy "legacy.c")

--- a/mylib/CMakeLists.txt
+++ b/mylib/CMakeLists.txt
@@ -1,9 +1,22 @@
 # 请改用自动批量查找所有 .cpp 和 .h 文件：
-set(mylib_sources "mylib/mylib.cpp" "mylib/mylib.h")
+file(GLOB mylib_sources CONFIGURE_DEPENDS mylib/*.cpp mylib/*.h)
 
 # 使用 SHARED 在 Windows 上会遇到什么困难？请尝试修复!
+# 当dll和exe不在同一目录时，只会查找exe所在目录和PATH
 add_library(mylib SHARED ${mylib_sources})
+set_property(TARGET mylib PROPERTY RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+set_property(TARGET mylib PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+set_property(TARGET mylib PROPERTY LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+set_property(TARGET mylib PROPERTY RUNTIME_OUTPUT_DIRECTORY_DEBUG ${PROJECT_BINARY_DIR})
+set_property(TARGET mylib PROPERTY ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${PROJECT_BINARY_DIR})
+set_property(TARGET mylib PROPERTY LIBRARY_OUTPUT_DIRECTORY_DEBUG ${PROJECT_BINARY_DIR})
+set_property(TARGET mylib PROPERTY RUNTIME_OUTPUT_DIRECTORY_RELEASE ${PROJECT_BINARY_DIR})
+set_property(TARGET mylib PROPERTY ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${PROJECT_BINARY_DIR})
+set_property(TARGET mylib PROPERTY LIBRARY_OUTPUT_DIRECTORY_RELEASE ${PROJECT_BINARY_DIR})
+
 target_compile_definitions(mylib PRIVATE MYLIB_EXPORT)
 
+
 # 这里应该用 PRIVATE 还是 PUBLIC？
-target_include_directories(mylib PRIVATE .)
+#target_include_directories(mylib PRIVATE .)
+target_include_directories(mylib PUBLIC .)


### PR DESCRIPTION
- 为什么不指定 cmake_minimum_required 会导致下面在 project 处出错？

​			因为CMakeList.txt至少需要3.10版本才可以运行.



- 这样设置 C++14 的方式对吗？请改正

  ​	1.这是针对gcc的用法，对MSVC用户不方便。
  ​	2.再次添加会导致冲突。

- 使用 SHARED 在 Windows 上会遇到什么困难？请尝试修复!
  1.当dll和exe不在同一目录时，只会查找exe所在目录和PATH。

  2.除了手动链接，可以使用CMake把dll文件生成到与exe相同的目录去。

  

- 自动批量的添加源文件
  1.使用GLOB 自动添加当前目录下指定扩展名的文件。
  2.GLOB_RECURSE 自动包含所有子文件夹的文件（需要将源码放到src目录下）。
